### PR TITLE
Don't free envvar on Linux

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -92,7 +92,9 @@ int GetAccessTokenFromIMDS(const char *type, MemoryStruct *accessToken)
     Log(LogLevel_Info, "Use overrided IDMS url : %s\n", IDMSEnv);
     strcat_s(idmsUrl, sizeof idmsUrl, IDMSEnv);
     strcat_s(idmsUrl, sizeof idmsUrl, "?api-version=2018-02-01");
+#ifdef _WIN32
     free(IDMSEnv);
+#endif
   }
   else
   {


### PR DESCRIPTION
From getenv man:

       As typically implemented, getenv() returns a pointer to a string
       within the environment list.  The caller must take care not to
       modify this string, since that would change the environment of
       the process.