### PR TITLE
Logging output belongs on stderr

### DIFF
--- a/src/pch.c
+++ b/src/pch.c
@@ -33,13 +33,13 @@ void WriteLog(
             }
         }
     }
-    printf("[%c] %s %s(%d) ",
+    fprintf(stderr, "[%c] %s %s(%d) ",
            level == LogLevel_Error ? 'e' : level == LogLevel_Info ? 'i'
                                                                   : 'd',
            function,
            shortFilename,
            line);
-    vprintf(format, arglist);
+    vfprintf(stderr, format, arglist);
     va_end(arglist);
-    printf("\n");
+    fprintf(stderr, "\n");
 }


### PR DESCRIPTION
Changed WriteLog to output messages on stderrr.  On stdout, the messages would be intermixed with actual output from the command utilizing the engine.